### PR TITLE
Improve version handling

### DIFF
--- a/src/amulet/game/abc/biome.py
+++ b/src/amulet/game/abc/biome.py
@@ -137,7 +137,7 @@ class DatabaseBiomeData(BiomeData):
             return self._to_universal[(biome.namespace, biome.base_name)]
         except KeyError:
             raise BiomeTranslationError(
-                f"Biome {biome} does not exist in version {self._game_version.platform} {self._game_version.min_version}"
+                f"Biome {biome} does not exist in version {self._game_version.platform} {self._game_version.min_semantic_version}"
             )
 
     def from_universal(
@@ -153,7 +153,7 @@ class DatabaseBiomeData(BiomeData):
             namespace, base_name = self._from_universal[biome]
         except KeyError:
             raise BiomeTranslationError(
-                f"Biome {biome} does not exist in version {self._game_version.platform} {self._game_version.min_version}"
+                f"Biome {biome} does not exist in version {self._game_version.platform} {self._game_version.min_semantic_version}"
             )
         else:
             return Biome(target_platform, target_version, namespace, base_name)

--- a/src/amulet/game/abc/block.py
+++ b/src/amulet/game/abc/block.py
@@ -244,7 +244,7 @@ class DatabaseBlockData(BlockData, ABC):
             translator = self._to_universal[(block.namespace, block.base_name)]
         except KeyError:
             raise BlockTranslationError(
-                f"Block {block} does not exist in version {self._game_version.platform} {self._game_version.min_version}"
+                f"Block {block} does not exist in version {self._game_version.platform} {self._game_version.min_semantic_version}"
             )
 
         output, extra_output, extra_needed, cacheable = translator.run(
@@ -294,7 +294,7 @@ class DatabaseBlockData(BlockData, ABC):
             translator = self._from_universal[(block.namespace, block.base_name)]
         except KeyError:
             raise BlockTranslationError(
-                f"Block {block} does not exist in version {self._game_version.platform} {self._game_version.min_version}"
+                f"Block {block} does not exist in version {self._game_version.platform} {self._game_version.min_semantic_version}"
             )
 
         output, extra_output, extra_needed, cacheable = translator.run(

--- a/src/amulet/game/abc/version.cpp
+++ b/src/amulet/game/abc/version.cpp
@@ -17,5 +17,11 @@ namespace game {
         return std::make_shared<BlockData>(_obj.attr("block"));
     }
 
+    VersionNumber GameVersion::get_max_known_block_version()
+    {
+        py::gil_scoped_acquire gil;
+        return _obj.attr("max_known_block_version").cast<VersionNumber>();
+    }
+
 } // namespace game
 } // namespace Amulet

--- a/src/amulet/game/abc/version.hpp
+++ b/src/amulet/game/abc/version.hpp
@@ -21,6 +21,8 @@ namespace game {
         using PyObjWrapper::PyObjWrapper;
         using PyObjWrapper::operator=;
 
+        AMULET_GAME_EXPORT VersionNumber get_max_known_block_version();
+
         AMULET_GAME_EXPORT std::shared_ptr<BiomeData> get_biome_data();
         AMULET_GAME_EXPORT std::shared_ptr<BlockData> get_block_data();
     };

--- a/src/amulet/game/abc/version.hpp
+++ b/src/amulet/game/abc/version.hpp
@@ -16,8 +16,6 @@ namespace py = pybind11;
 namespace Amulet {
 namespace game {
 
-    class GameVersionImpl;
-
     class GameVersion : public PyObjWrapper {
     public:
         using PyObjWrapper::PyObjWrapper;

--- a/src/amulet/game/abc/version.py
+++ b/src/amulet/game/abc/version.py
@@ -23,14 +23,90 @@ class GameVersion(ABC):
 
     @property
     @abstractmethod
-    def min_version(self) -> VersionNumber:
-        """The minimum game version this instance can be used with."""
+    def min_semantic_version(self) -> VersionNumber:
+        """
+        The minimum semantic version this instance can be used with.
+
+        >>> game_version: GameVersion
+        >>> game_version.min_semantic_version
+        VersionNumber(1, 21, 9)
+        """
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def max_version(self) -> VersionNumber:
-        """The maximum game version this instance can be used with."""
+    def max_known_semantic_version(self) -> VersionNumber:
+        """
+        The maximum known semantic version this instance can be used with.
+        This instance may be compatible with higher versions but this is the highest it is known to work with.
+
+        >>> game_version: GameVersion
+        >>> game_version.max_known_semantic_version
+        VersionNumber(1, 21, 9)
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def max_semantic_version(self) -> VersionNumber:
+        """
+        The maximum semantic version this instance should accept.
+        Note that this is usually not a valid version.
+
+        >>> game_version: GameVersion
+        >>> game_version.max_semantic_version
+        VersionNumber(1, 22, 10, -1)
+        VersionNumber(2, -1)  # This is used in the newest version.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def min_block_version(self) -> VersionNumber:
+        """
+        The minimum block version this instance can be used with.
+
+        >>> game_version: GameVersion
+        >>> game_version.min_block_version
+        # Java - data version
+        VersionNumber(4553)  # 1.21.9 Release Candidate 1
+        # Bedrock - uint8[4] interpreted as uint32
+        VersionNumber(18168865)  # 1.21.60.33
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def max_known_block_version(self) -> VersionNumber:
+        """
+        The maximum known block version this instance can be used with.
+        This instance may be compatible with higher versions but this is the highest it is known to work with.
+
+        >>> game_version: GameVersion
+        >>> game_version.max_known_block_version
+        # Java - data version
+        VersionNumber(4554)  # 1.21.9
+        # Bedrock - uint8[4] interpreted as uint32
+        VersionNumber(18168865)  # 1.21.60.33
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def max_block_version(self) -> VersionNumber:
+        """
+        The maximum block version this instance should accept.
+        Note that this is usually not a valid version.
+
+        >>> game_version: GameVersion
+        >>> game_version.max_block_version
+        # Java - data version
+        VersionNumber(4554)  # Java Edition 1.21.9
+        VersionNumber(2147483647)  # The newest version uses max(int32) to catch all future versions.
+        # Bedrock - uint8[4] interpreted as uint32
+        VersionNumber(18168865)  # 1.21.60.33
+        VersionNumber(4294967295)  # The newest version uses max(uint32) to catch all future versions.
+        """
         raise NotImplementedError
 
     @property

--- a/src/amulet/game/bedrock/_version.py
+++ b/src/amulet/game/bedrock/_version.py
@@ -43,8 +43,8 @@ class BedrockGameVersion(GameVersion):
 
     def supports_version(self, platform: str, version: VersionNumber) -> bool:
         return platform == "bedrock" and (
-                self._min_block_version <= version <= self._max_block_version
-                or self._min_semantic_version <= version <= self._max_semantic_version
+            self._min_block_version <= version <= self._max_block_version
+            or self._min_semantic_version <= version <= self._max_semantic_version
         )
 
     @classmethod

--- a/src/amulet/game/bedrock/_version.py
+++ b/src/amulet/game/bedrock/_version.py
@@ -26,21 +26,25 @@ class BedrockGameVersion(GameVersion):
 
     def __init__(
         self,
-        min_data_version: VersionNumber,
-        max_data_version: VersionNumber,
+        min_block_version: VersionNumber,
+        max_known_block_version: VersionNumber,
+        max_block_version: VersionNumber,
         min_semantic_version: VersionNumber,
+        max_known_semantic_version: VersionNumber,
         max_semantic_version: VersionNumber,
     ) -> None:
         """Do not use this."""
-        self._min_data_version = min_data_version
-        self._max_data_version = max_data_version
+        self._min_block_version = min_block_version
+        self._max_known_block_version = max_known_block_version
+        self._max_block_version = max_block_version
         self._min_semantic_version = min_semantic_version
+        self._max_known_semantic_version = max_known_semantic_version
         self._max_semantic_version = max_semantic_version
 
     def supports_version(self, platform: str, version: VersionNumber) -> bool:
         return platform == "bedrock" and (
-            self._min_data_version <= version <= self._max_data_version
-            or self._min_semantic_version <= version <= self._max_semantic_version
+                self._min_block_version <= version <= self._max_block_version
+                or self._min_semantic_version <= version <= self._max_semantic_version
         )
 
     @classmethod
@@ -50,9 +54,11 @@ class BedrockGameVersion(GameVersion):
         with open(os.path.join(version_path, "__init__.json")) as f:
             init = json.load(f)
         assert init["platform"] == "bedrock"
-        min_data_version = VersionNumber(init.get("data_version", -1))
-        max_data_version = VersionNumber(init.get("data_version_max", -1))
+        min_block_version = VersionNumber(init.get("data_version", -1))
+        max_known_block_version = VersionNumber(init.get("data_version_max_known", -1))
+        max_block_version = VersionNumber(init.get("data_version_max", -1))
         min_semantic_version = VersionNumber(*init["version"])
+        max_known_sematic_version = VersionNumber(*init["version_max_known"])
         max_semantic_version = VersionNumber(*init["version_max"])
 
         block_format = {
@@ -64,9 +70,11 @@ class BedrockGameVersion(GameVersion):
             universal_version = get_game_version("universal", VersionNumber(1))
 
         self = cls(
-            min_data_version,
-            max_data_version,
+            min_block_version,
+            max_known_block_version,
+            max_block_version,
             min_semantic_version,
+            max_known_sematic_version,
             max_semantic_version,
         )
 
@@ -148,19 +156,35 @@ class BedrockGameVersion(GameVersion):
         return self
 
     def __repr__(self) -> str:
-        return f"BedrockGameVersion({self.min_version!r})"
+        return f"BedrockGameVersion({self.min_semantic_version!r})"
 
     @property
     def platform(self) -> str:
         return "bedrock"
 
     @property
-    def min_version(self) -> VersionNumber:
+    def min_semantic_version(self) -> VersionNumber:
         return self._min_semantic_version
 
     @property
-    def max_version(self) -> VersionNumber:
+    def max_known_semantic_version(self) -> VersionNumber:
+        return self._max_known_semantic_version
+
+    @property
+    def max_semantic_version(self) -> VersionNumber:
         return self._max_semantic_version
+
+    @property
+    def min_block_version(self) -> VersionNumber:
+        return self._min_block_version
+
+    @property
+    def max_known_block_version(self) -> VersionNumber:
+        return self._max_known_block_version
+
+    @property
+    def max_block_version(self) -> VersionNumber:
+        return self._max_block_version
 
     @property
     def block(self) -> BedrockBlockData:

--- a/src/amulet/game/game.py
+++ b/src/amulet/game/game.py
@@ -36,7 +36,7 @@ def _get_versions() -> dict[str, list[GameVersion]]:
                 versions: object = pickle.loads(gzip.decompress(pkl.read()))
 
             def version_sort(v: GameVersion) -> VersionNumber:
-                return v.min_version
+                return v.min_semantic_version
 
             sorted_versions: dict[str, list[GameVersion]] = {}
             for platform, version_list in dynamic_cast(versions, dict).items():

--- a/src/amulet/game/java/version.py
+++ b/src/amulet/game/java/version.py
@@ -27,14 +27,18 @@ class JavaGameVersion(GameVersion):
     def __init__(
         self,
         min_data_version: VersionNumber,
+        max_known_data_version: VersionNumber,
         max_data_version: VersionNumber,
         min_semantic_version: VersionNumber,
+        max_known_semantic_version: VersionNumber,
         max_semantic_version: VersionNumber,
     ):
         """Do not use this."""
         self._min_data_version = min_data_version
+        self._max_known_data_version = max_known_data_version
         self._max_data_version = max_data_version
         self._min_semantic_version = min_semantic_version
+        self._max_known_semantic_version = max_known_semantic_version
         self._max_semantic_version = max_semantic_version
 
     @classmethod
@@ -45,8 +49,10 @@ class JavaGameVersion(GameVersion):
             init = json.load(f)
         assert init["platform"] == "java"
         min_data_version = VersionNumber(init["data_version"])
+        max_known_data_version = VersionNumber(init["data_version_max_known"])
         max_data_version = VersionNumber(init["data_version_max"])
         min_semantic_version = VersionNumber(*init["version"])
+        max_known_semantic_version = VersionNumber(*init["version_max_known"])
         max_semantic_version = VersionNumber(*init["version_max"])
 
         block_format = init["block_format"]
@@ -55,8 +61,10 @@ class JavaGameVersion(GameVersion):
 
         self = cls(
             min_data_version,
+            max_known_data_version,
             max_data_version,
             min_semantic_version,
+            max_known_semantic_version,
             max_semantic_version,
         )
 
@@ -153,7 +161,7 @@ class JavaGameVersion(GameVersion):
         return self
 
     def __repr__(self) -> str:
-        return f"JavaGameVersion({self.min_version!r})"
+        return f"JavaGameVersion({self.min_semantic_version!r})"
 
     def supports_version(self, platform: str, version: VersionNumber) -> bool:
         return platform == "java" and (
@@ -166,11 +174,39 @@ class JavaGameVersion(GameVersion):
         return "java"
 
     @property
-    def min_version(self) -> VersionNumber:
+    def min_semantic_version(self) -> VersionNumber:
+        return self._min_semantic_version
+
+    @property
+    def max_known_semantic_version(self) -> VersionNumber:
+        return self._max_known_semantic_version
+
+    @property
+    def max_semantic_version(self) -> VersionNumber:
+        return self._max_semantic_version
+
+    @property
+    def min_data_version(self) -> VersionNumber:
         return self._min_data_version
 
     @property
-    def max_version(self) -> VersionNumber:
+    def max_known_data_version(self) -> VersionNumber:
+        return self._max_known_data_version
+
+    @property
+    def max_data_version(self) -> VersionNumber:
+        return self._max_data_version
+
+    @property
+    def min_block_version(self) -> VersionNumber:
+        return self._min_data_version
+
+    @property
+    def max_known_block_version(self) -> VersionNumber:
+        return self._max_known_data_version
+
+    @property
+    def max_block_version(self) -> VersionNumber:
         return self._max_data_version
 
     @property

--- a/src/amulet/game/universal/_version.py
+++ b/src/amulet/game/universal/_version.py
@@ -52,11 +52,27 @@ class UniversalVersion(GameVersion):
         return "universal"
 
     @property
-    def min_version(self) -> VersionNumber:
+    def min_semantic_version(self) -> VersionNumber:
         return VersionNumber(1)
 
     @property
-    def max_version(self) -> VersionNumber:
+    def max_known_semantic_version(self) -> VersionNumber:
+        return VersionNumber(1)
+
+    @property
+    def max_semantic_version(self) -> VersionNumber:
+        return VersionNumber(1)
+
+    @property
+    def min_block_version(self) -> VersionNumber:
+        return VersionNumber(1)
+
+    @property
+    def max_known_block_version(self) -> VersionNumber:
+        return VersionNumber(1)
+
+    @property
+    def max_block_version(self) -> VersionNumber:
         return VersionNumber(1)
 
     @property

--- a/tools/minify_json.py
+++ b/tools/minify_json.py
@@ -17,7 +17,9 @@ def main() -> None:
     from amulet.game.bedrock import BedrockGameVersion
     from amulet.game.universal import UniversalVersion
 
-    json_path = os.path.join(root_path, "submodules", "PyMCTranslate", "PyMCTranslate", "json")
+    json_path = os.path.join(
+        root_path, "submodules", "PyMCTranslate", "PyMCTranslate", "json"
+    )
 
     universal_version = UniversalVersion.from_json(
         os.path.join(json_path, "versions", "universal")
@@ -46,11 +48,9 @@ def main() -> None:
             pass
         else:
             raise RuntimeError
-    with open(
-        os.path.join(src_dir, "amulet", "game", "versions.pkl.gz"), "wb"
-    ) as pkl:
+    with open(os.path.join(src_dir, "amulet", "game", "versions.pkl.gz"), "wb") as pkl:
         pkl.write(gzip.compress(pickle.dumps(_versions)))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tools/minify_json.py
+++ b/tools/minify_json.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import glob
+import json
+import gzip
+import pickle
+
+
+def main() -> None:
+    # This is rather janky but it is a stop-gap until the whole library can be ported to C++
+    root_path = os.path.dirname(os.path.dirname(__file__))
+    src_dir = os.path.join(root_path, "src")
+    sys.path.append(src_dir)
+
+    from amulet.game.abc import GameVersion
+    from amulet.game.java import JavaGameVersion
+    from amulet.game.bedrock import BedrockGameVersion
+    from amulet.game.universal import UniversalVersion
+
+    json_path = os.path.join(root_path, "submodules", "PyMCTranslate", "PyMCTranslate", "json")
+
+    universal_version = UniversalVersion.from_json(
+        os.path.join(json_path, "versions", "universal")
+    )
+    _versions: dict[str, list[GameVersion]] = {
+        "universal": [universal_version],
+    }
+    for init_path in glob.glob(
+        os.path.join(glob.escape(json_path), "versions", "*", "__init__.json")
+    ):
+        version_path = os.path.dirname(init_path)
+
+        with open(os.path.join(version_path, "__init__.json")) as f:
+            init = json.load(f)
+
+        platform = init["platform"]
+        if platform == "bedrock":
+            _versions.setdefault("bedrock", []).append(
+                BedrockGameVersion.from_json(version_path, universal_version)
+            )
+        elif platform == "java":
+            _versions.setdefault("java", []).append(
+                JavaGameVersion.from_json(version_path, universal_version)
+            )
+        elif platform == "universal":
+            pass
+        else:
+            raise RuntimeError
+    with open(
+        os.path.join(src_dir, "amulet", "game", "versions.pkl.gz"), "wb"
+    ) as pkl:
+        pkl.write(gzip.compress(pickle.dumps(_versions)))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Remove `min_version` and `max_version`. These behaviour of these properties was confusing.
Add (`min`/`max`/`max_known`) `semantic_version` and `block_version` properties.
These are clearer what they do.
max_known indicates a real version to use as an upper bound. max is generally not a real version and exists purely to catch future versions.